### PR TITLE
Remove list for External Documentation Objects

### DIFF
--- a/src/Neuroglia.AsyncApi.Core/v2/AsyncApiDocument.cs
+++ b/src/Neuroglia.AsyncApi.Core/v2/AsyncApiDocument.cs
@@ -79,10 +79,10 @@ public record AsyncApiDocument
     public virtual EquatableList<TagDefinition>? Tags { get; set; }
 
     /// <summary>
-    /// Gets/sets a <see cref="List{T}"/> containing additional external documentation.
+    /// Gets/sets an object containing additional external documentation.
     /// </summary>
     [DataMember(Order = 9, Name = "externalDocs"), JsonPropertyOrder(9), JsonPropertyName("externalDocs"), YamlMember(Order = 9, Alias = "externalDocs")]
-    public virtual EquatableList<ExternalDocumentationDefinition>? ExternalDocs { get; set; }
+    public virtual ExternalDocumentationDefinition? ExternalDocs { get; set; }
 
     /// <summary>
     /// Attempts to get the <see cref="OperationDefinition"/> with the specified id

--- a/src/Neuroglia.AsyncApi.Core/v2/MessageTraitDefinition.cs
+++ b/src/Neuroglia.AsyncApi.Core/v2/MessageTraitDefinition.cs
@@ -81,10 +81,10 @@ public record MessageTraitDefinition
     public virtual EquatableList<TagDefinition>? Tags { get; set; }
 
     /// <summary>
-    /// Gets/sets a <see cref="EquatableList{T}"/> containing additional external documentation for this message.
+    /// Gets/sets an object containing additional external documentation for this message.
     /// </summary>
     [DataMember(Order = 10, Name = "externalDocs"), JsonPropertyOrder(10), JsonPropertyName("externalDocs"), YamlMember(Order = 10, Alias = "externalDocs")]
-    public virtual EquatableList<ExternalDocumentationDefinition>? ExternalDocs { get; set; }
+    public virtual ExternalDocumentationDefinition? ExternalDocs { get; set; }
 
     /// <summary>
     /// Gets/sets an object used to configure the <see cref="MessageTraitDefinition"/>'s <see cref="IMessageBindingDefinition"/>s

--- a/src/Neuroglia.AsyncApi.Core/v2/OperationTraitDefinition.cs
+++ b/src/Neuroglia.AsyncApi.Core/v2/OperationTraitDefinition.cs
@@ -48,10 +48,10 @@ public record OperationTraitDefinition
     public virtual EquatableList<TagDefinition>? Tags { get; set; }
 
     /// <summary>
-    /// Gets/sets a <see cref="List{T}"/> containing additional external documentation for this operation.
+    /// Gets/sets an object containing additional external documentation for this operation.
     /// </summary>
     [DataMember(Order = 5, Name = "externalDocs"), JsonPropertyOrder(5), JsonPropertyName("externalDocs"), YamlMember(Order = 5, Alias = "externalDocs")]
-    public virtual EquatableList<ExternalDocumentationDefinition>? ExternalDocs { get; set; }
+    public virtual ExternalDocumentationDefinition? ExternalDocs { get; set; }
 
     /// <summary>
     /// Gets/sets an object used to configure the <see cref="OperationTraitDefinition"/>'s <see cref="IOperationBindingDefinition"/>s

--- a/src/Neuroglia.AsyncApi.Core/v2/TagDefinition.cs
+++ b/src/Neuroglia.AsyncApi.Core/v2/TagDefinition.cs
@@ -34,10 +34,10 @@ public record TagDefinition
     public virtual string? Description { get; set; }
 
     /// <summary>
-    /// Gets/sets a <see cref="List{T}"/> containing additional external documentation for this tag.
+    /// Gets/sets an object containing additional external documentation for this tag.
     /// </summary>
     [DataMember(Order = 3, Name = "externalDocs"), JsonPropertyOrder(3), JsonPropertyName("externalDocs"), YamlMember(Order = 3, Alias = "externalDocs")]
-    public virtual EquatableList<ExternalDocumentationDefinition>? ExternalDocs { get; set; }
+    public virtual ExternalDocumentationDefinition? ExternalDocs { get; set; }
 
     /// <inheritdoc/>
     public override string ToString() => Name;

--- a/src/Neuroglia.AsyncApi.FluentBuilders/AsyncApiDocumentBuilder.cs
+++ b/src/Neuroglia.AsyncApi.FluentBuilders/AsyncApiDocumentBuilder.cs
@@ -132,8 +132,7 @@ public class AsyncApiDocumentBuilder(IServiceProvider serviceProvider, IEnumerab
     public virtual IAsyncApiDocumentBuilder WithExternalDocumentation(Uri uri, string? description = null)
     {
         ArgumentNullException.ThrowIfNull(uri);
-        this.Document.ExternalDocs ??= [];
-        this.Document.ExternalDocs.Add(new() { Url = uri, Description = description });
+        this.Document.ExternalDocs = new() { Url = uri, Description = description };
         return this;
     }
 

--- a/src/Neuroglia.AsyncApi.FluentBuilders/MessageTraitDefinitionBuilder.cs
+++ b/src/Neuroglia.AsyncApi.FluentBuilders/MessageTraitDefinitionBuilder.cs
@@ -66,8 +66,7 @@ public abstract class MessageTraitDefinitionBuilder<TBuilder, TTrait>
     public virtual TBuilder WithExternalDocumentation(Uri uri, string? description = null)
     {
         ArgumentNullException.ThrowIfNull(uri);
-        this.Trait.ExternalDocs ??= [];
-        this.Trait.ExternalDocs.Add(new ExternalDocumentationDefinition() { Url = uri, Description = description });
+        this.Trait.ExternalDocs = new ExternalDocumentationDefinition() { Url = uri, Description = description };
         return (TBuilder)(object)this;
     }
 

--- a/src/Neuroglia.AsyncApi.FluentBuilders/OperationTraitDefinitionBuilder.cs
+++ b/src/Neuroglia.AsyncApi.FluentBuilders/OperationTraitDefinitionBuilder.cs
@@ -57,8 +57,7 @@ public abstract class OperationTraitDefinitionBuilder<TBuilder, TTrait>
     public virtual TBuilder WithExternalDocumentation(Uri uri, string? description = null)
     {
         ArgumentNullException.ThrowIfNull(uri);
-        this.Trait.ExternalDocs ??= [];
-        this.Trait.ExternalDocs.Add(new ExternalDocumentationDefinition() { Url = uri, Description = description });
+        this.Trait.ExternalDocs = new ExternalDocumentationDefinition() { Url = uri, Description = description };
         return (TBuilder)(object)this;
     }
 

--- a/src/Neuroglia.AsyncApi.FluentBuilders/TagDefinitionBuilder.cs
+++ b/src/Neuroglia.AsyncApi.FluentBuilders/TagDefinitionBuilder.cs
@@ -55,8 +55,7 @@ public class TagDefinitionBuilder(IEnumerable<IValidator<TagDefinition>> validat
     public virtual ITagDefinitionBuilder WithExternalDocumentation(Uri uri, string? description = null)
     {
         ArgumentNullException.ThrowIfNull(uri);
-        this.Tag.ExternalDocs ??= [];
-        this.Tag.ExternalDocs.Add(new() { Url = uri, Description = description });
+        this.Tag.ExternalDocs = new() { Url = uri, Description = description };
         return this;
     }
 

--- a/tests/Neuroglia.AsyncApi.UnitTests/Cases/Fluent/FluentBuilderTests.cs
+++ b/tests/Neuroglia.AsyncApi.UnitTests/Cases/Fluent/FluentBuilderTests.cs
@@ -143,6 +143,9 @@ public class FluentBuilderTests
         document.Info.License.Url.Should().Be(licenseUri);
         document.Info.TermsOfService.Should().Be(termsOfServiceUri);
         document.DefaultContentType.Should().Be(defaultContentType);
+        document.ExternalDocs.Should().NotBeNull();
+        document.ExternalDocs!.Description.Should().Be(tagDocumentationDescription);
+        document.ExternalDocs.Url.Should().Be(tagDocumentationUri);
 
         var server = document.Servers!.SingleOrDefault();
         server.Should().NotBeNull();
@@ -189,16 +192,9 @@ public class FluentBuilderTests
         tag.Should().NotBeNull();
         tag!.Name.Should().Be(tagName);
         tag.Description.Should().Be(tagDescription);
-
-        var externalDoc = tag.ExternalDocs!.FirstOrDefault();
-        externalDoc.Should().NotBeNull();
-        externalDoc!.Description.Should().Be(tagDocumentationDescription);
-        externalDoc.Url.Should().Be(tagDocumentationUri);
-
-        externalDoc = document.ExternalDocs!.FirstOrDefault();
-        externalDoc.Should().NotBeNull();
-        externalDoc!.Description.Should().Be(tagDocumentationDescription);
-        externalDoc.Url.Should().Be(tagDocumentationUri);
+        tag.ExternalDocs.Should().NotBeNull();
+        tag.ExternalDocs!.Description.Should().Be(tagDocumentationDescription);
+        tag.ExternalDocs.Url.Should().Be(tagDocumentationUri);
     }
 
     void IDisposable.Dispose()

--- a/tests/Neuroglia.AsyncApi.UnitTests/Services/AsyncApiDocumentFactory.cs
+++ b/tests/Neuroglia.AsyncApi.UnitTests/Services/AsyncApiDocumentFactory.cs
@@ -101,28 +101,22 @@ internal static class AsyncApiDocumentFactory
                                 //todo
                             },
                             Traits = [],
-                            ExternalDocs =
-                            [
-                                new ExternalDocumentationDefinition()
-                                {
-                                    Url = new("https://fake.contact.com"),
-                                    Description = "Fake Documentation Description"
-                                }
-                            ],
+                            ExternalDocs = new()
+                            {
+                                Url = new("https://fake.contact.com"),
+                                Description = "Fake Documentation Description"
+                            },
                             Tags =
                             [
                                 new TagDefinition()
                                 {
                                     Name = "fake-tag",
                                     Description = "Fake Tag Description",
-                                    ExternalDocs =
-                                    [
-                                        new ExternalDocumentationDefinition()
-                                        {
-                                            Url = new("https://fake.contact.com"),
-                                            Description = "Fake Documentation Description"
-                                        }
-                                    ]
+                                    ExternalDocs = new()
+                                    {
+                                        Url = new("https://fake.contact.com"),
+                                        Description = "Fake Documentation Description"
+                                    }
                                 }
                             ]
                         },
@@ -140,28 +134,22 @@ internal static class AsyncApiDocumentFactory
                 }
             },
             DefaultContentType = MediaTypeNames.Application.Json,
-            ExternalDocs = 
-            [
-                new ExternalDocumentationDefinition()
-                {
-                    Url = new("https://fake.contact.com"),
-                    Description = "Fake Documentation Description"
-                }
-            ],
+            ExternalDocs = new()
+            {
+                Url = new("https://fake.contact.com"),
+                Description = "Fake Documentation Description"
+            },
             Tags =
             [
                 new TagDefinition()
                 {
                     Name = "fake-tag",
                     Description = "Fake Tag Description",
-                    ExternalDocs =
-                    [
-                        new ExternalDocumentationDefinition()
-                        {
-                            Url = new("https://fake.contact.com"),
-                            Description = "Fake Documentation Description"
-                        }
-                    ]
+                    ExternalDocs = new()
+                    {
+                        Url = new("https://fake.contact.com"),
+                        Description = "Fake Documentation Description"
+                    }
                 }
             ]
         };


### PR DESCRIPTION
The [External Documentation Object](https://v2.asyncapi.com/docs/reference/specification/v2.6.0#externalDocumentationObject) (`ExternalDocumentationDefinition`) is specified as a single object instead of a list in the following objects:
- [AsyncAPI Object](https://v2.asyncapi.com/docs/reference/specification/v2.6.0#A2SObject) (`AsyncApiDocument`)
- [Operation Object](https://v2.asyncapi.com/docs/reference/specification/v2.6.0#operationObject) (`OperationDefinition` inherits from `OperationTraitDefinition`)
- [Operation Trait Object](https://v2.asyncapi.com/docs/reference/specification/v2.6.0#operationTraitObject) (`OperationTraitDefinition`)
- [Message Object](https://v2.asyncapi.com/docs/reference/specification/v2.6.0#messageObject) (`MessageDefinition` inherits from `MessageTraitDefinition`)
- [Message Trait Object](https://v2.asyncapi.com/docs/reference/specification/v2.6.0#messageTraitObject) (`MessageTraitDefinition`)
- [Tag Object](https://v2.asyncapi.com/docs/reference/specification/v2.6.0#tagObject) (`TagDefinition`)