### PR TITLE
Rename application/schema+json to application/vnd.aai.asyncapi+json;v…

### DIFF
--- a/samples/StreetLightsApi/Program.cs
+++ b/samples/StreetLightsApi/Program.cs
@@ -1,4 +1,4 @@
-// Copyright © 2021-Present Neuroglia SRL. All rights reserved.
+// Copyright ï¿½ 2021-Present Neuroglia SRL. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"),
 // you may not use this file except in compliance with the License.
@@ -260,7 +260,7 @@ builder.Services.AddAsyncApiDocument(document => document
         .WithTrait(trait => trait
             .Use("#/components/messageTraits/cloud-event"))
         .WithPayloadSchema(schema => schema
-            .WithFormat("application/schema+json")
+            .WithFormat("application/vnd.aai.asyncapi+json;version=3.0.0")
             .WithSchema(lightMeasuredEventSchema))
         .WithCorrelationId(setup => setup
             .WithLocation("$message.payload#/subject"))
@@ -273,7 +273,7 @@ builder.Services.AddAsyncApiDocument(document => document
         .WithTrait(trait => trait
             .Use("#/components/messageTraits/cloud-event"))
         .WithPayloadSchema(schema => schema
-            .WithFormat("application/schema+json")
+            .WithFormat("application/vnd.aai.asyncapi+json;version=3.0.0")
             .WithSchema(movementDetectedEventSchema))
         .WithCorrelationId(setup => setup
             .WithLocation("$message.payload#/subject"))

--- a/src/Neuroglia.AsyncApi.AspNetCore.UI/Pages/Shared/v3/_V3Schema.cshtml
+++ b/src/Neuroglia.AsyncApi.AspNetCore.UI/Pages/Shared/v3/_V3Schema.cshtml
@@ -3,10 +3,10 @@
 @inject Neuroglia.AsyncApi.Generation.IJsonSchemaExampleGenerator ExampleGenerator
 @{
     var schemaContext = Model.Context == SchemaContext.Unknown ? string.Empty : EnumHelper.Stringify(Model.Context);
-    var schemaFormat = Model.Definition.SchemaFormat?.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)[0] ?? "application/schema+json";
+    var schemaFormat = Model.Definition.SchemaFormat?.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)[0] ?? "application/vnd.aai.asyncapi+json;version=3.0.0";
     switch (schemaFormat)
     {
-        case "application/schema+json":
+        case "application/vnd.aai.asyncapi+json;version=3.0.0":
             var schema = Model.Definition.Schema is JsonSchema jsonSchema ? jsonSchema : JsonSerializer.Deserialize<JsonSchema>(JsonSerializer.SerializeToText(Model.Definition))!;
             var type = schema.GetJsonType()!;
             var properties = schema.GetProperties();

--- a/src/Neuroglia.AsyncApi.Client/SchemaFormat.cs
+++ b/src/Neuroglia.AsyncApi.Client/SchemaFormat.cs
@@ -30,7 +30,7 @@ public static class SchemaFormat
     /// <summary>
     /// Gets the format for JSON Schemas
     /// </summary>
-    public const string Json = "application/schema+json";
+    public const string Json = "application/vnd.aai.asyncapi+json;version=3.0.0";
     /// <summary>
     /// Gets the format for XML Schemas
     /// </summary>

--- a/src/Neuroglia.AsyncApi.FluentBuilders/v3/V3SchemaDefinitionBuilder.cs
+++ b/src/Neuroglia.AsyncApi.FluentBuilders/v3/V3SchemaDefinitionBuilder.cs
@@ -50,7 +50,7 @@ public class V3SchemaDefinitionBuilder(IServiceProvider serviceProvider, IEnumer
         ArgumentNullException.ThrowIfNull(setup);
         var builder = new JsonSchemaBuilder();
         setup(builder);
-        Schema.SchemaFormat = "application/schema+json";
+        Schema.SchemaFormat = "application/vnd.aai.asyncapi+json;version=3.0.0";
         Schema.Schema = builder.Build();
     }
 

--- a/src/Neuroglia.AsyncApi.Generation/AsyncApiDocumentGenerator.v3.cs
+++ b/src/Neuroglia.AsyncApi.Generation/AsyncApiDocumentGenerator.v3.cs
@@ -310,7 +310,7 @@ public partial class AsyncApiDocumentGenerator
             {
                 message
                     .WithPayloadSchema(schema => schema
-                        .WithFormat("application/schema+json")
+                        .WithFormat("application/vnd.aai.asyncapi+json;version=3.0.0")
                         .WithSchema(requestMessagePayloadSchema));
             }
             if (!string.IsNullOrWhiteSpace(requestMessageAttribute?.HeadersSchema))
@@ -321,7 +321,7 @@ public partial class AsyncApiDocumentGenerator
             {
                 message
                     .WithHeadersSchema(schema => schema
-                        .WithFormat("application/schema+json")
+                        .WithFormat("application/vnd.aai.asyncapi+json;version=3.0.0")
                         .WithSchema(requestMessageHeadersSchema));
             }
             if (requestMessageAttribute?.ExternalDocumentationUrl != null)


### PR DESCRIPTION
Rename `application/schema+json` to `application/vnd.aai.asyncapi+json;version=3.0.0` across the project that uses Async API 3.0.0. 

This is the Async API's accepted value according to https://www.asyncapi.com/docs/reference/specification/v3.0.0#multiFormatSchemaFormatTable
